### PR TITLE
fix proportional-distributor.py

### DIFF
--- a/tools/proportional-distributor/proportional-distributor.py
+++ b/tools/proportional-distributor/proportional-distributor.py
@@ -390,7 +390,7 @@ def transfer(input_path, interactive, drop_amount, mint,
     with open(log_failed, "a") as lfa:
         lfa.write('recipient,amount,error\n')
     with open(log_unconfirmed, "a") as lu:
-        lu.write('recipient,amount,error')
+        lu.write('recipient,amount,error\n')
     # endregion
 
     print()

--- a/tools/proportional-distributor/proportional-distributor.py
+++ b/tools/proportional-distributor/proportional-distributor.py
@@ -132,6 +132,8 @@ class TransferCmd:
         self.url = url
         if options is None:
             self.options = []
+        else:
+            self.options = options
 
     def to_str(self):
         return f"{self.cmd} {self.instruction} {self.mint_address} {self.drop_amount:.{self.decimals}f} {self.recipient} {' '.join(self.options)}"


### PR DESCRIPTION
FYI, all the fixes are the same as #1

## Fix `options`

### context

If my understanding is correct, this `options` leaves flexibilities to add arguments like `--fund-recipient` and `--allow-unfunded-recipient` for `spl-token` command.


### issue
Without this modification, the `to_str()` will fail because the `self.options` is always `None`
It is not a critical bug, but maybe worth to fix it.


## Fix csv header of unconfirmed log:
`lu.write('recipient,amount,error')` -> `lu.write('recipient,amount,error\n')`