### PR TITLE
fix: csv headers of log should contain newline

### DIFF
--- a/tools/flat-distributor/flat-distributor.py
+++ b/tools/flat-distributor/flat-distributor.py
@@ -384,7 +384,7 @@ def transfer(input_path, interactive, drop_amount, mint,
     with open(log_failed, "a") as lfa:
         lfa.write('recipient,amount,error\n')
     with open(log_unconfirmed, "a") as lu:
-        lu.write('recipient,amount,error')
+        lu.write('recipient,amount,error\n')
     # endregion
 
     print()

--- a/tools/proportional-distributor/proportional-distributor.py
+++ b/tools/proportional-distributor/proportional-distributor.py
@@ -388,7 +388,7 @@ def transfer(input_path, interactive, drop_amount, mint,
     with open(log_failed, "a") as lfa:
         lfa.write('recipient,amount,error\n')
     with open(log_unconfirmed, "a") as lu:
-        lu.write('recipient,amount,error')
+        lu.write('recipient,amount,error\n')
     # endregion
 
     print()


### PR DESCRIPTION
I found the header of the unconfirmed log is lack of newline, so I added it back.