### PR TITLE
Merge funding-options feature

### DIFF
--- a/tools/flat-distributor/README.md
+++ b/tools/flat-distributor/README.md
@@ -56,7 +56,7 @@ Also, consider the possible security issues when using file-system wallets ([Sol
 This command will generate multiple log files, the location and names of which can be set in the 'config.env' file.
 Use the option`--non-interactive` to run the distribution in non-interactive mode, where each transaction doesn't have to be confirmed.
 
-The transaction will succeed only if the recipient is funded and his (asssociated) token account exists.
+If sending tokens to owner accounts that do not have a minted associated token address, use `--fund-recipient` option. For accounts that are unfunded (i.e. have 0 SOL), use `--allow-unfunded-recipient`. Both options behave just as they do in the `spl-token transfer` command. 
 
 Execution can be interrupted at any time with SIGINT (CTRL+C).
 

--- a/tools/flat-distributor/flat-distributor.py
+++ b/tools/flat-distributor/flat-distributor.py
@@ -153,6 +153,55 @@ def run(cmd):
     return proc.returncode, stdout, stderr
 
 
+def try_transfer(cmd, addr, drop, log_success, log_unconfirmed, log_failed,
+                 TOO_MANY_REQUESTS, RPC_ERROR, UNCONFIRMED):
+    log_detail_entry = ''
+    while True:
+        code, out, err = run(cmd.to_list())
+        if code == 0:
+            output = out.decode('utf-8')
+            print(
+                f'{bcolors.OKGREEN}SUCCESS{bcolors.ENDC}', flush=True)
+            sig = parse_sig(output)
+            with open(log_success, 'a') as ls:
+                ls.write(f'{addr},{drop:f},{sig}\n')
+            log_detail_entry += output + '\n'
+            break
+        else:
+            err_msg = err.decode('utf-8')
+            if TOO_MANY_REQUESTS in err_msg:
+                print('429, waiting 5... ', end='', flush=True)
+                time.sleep(5)
+                log_detail_entry += err_msg + '\n'
+                continue
+            if RPC_ERROR in err_msg:
+                print('-32005 RPC Error, waiting 5... ',
+                        end='', flush=True)
+                log_detail_entry += err_msg + '\n'
+                time.sleep(5)
+                continue
+            if UNCONFIRMED in err_msg:
+                print(
+                    f'{bcolors.DANGER}UNCONFIRMED{bcolors.ENDC}', flush=True)
+                with open(log_unconfirmed, "a") as lu:
+                    lu.write(f'{addr},{drop:f},{err_msg}')
+                log_detail_entry += err_msg + '\n'
+                break
+
+            print(f'{bcolors.FAIL}FAILED{bcolors.ENDC}', flush=True)
+            try:
+                err_short = err_msg.split('\n', 1)[0] + '\n'
+                err_short = re.sub(r"[,]", ' ', err_short)
+            except (IndexError, Exception):
+                err_short = 'Error parsing error description - read the full logs.\n'
+            finally:
+                with open(log_failed, 'a') as lfa:
+                    lfa.write(f'{addr},{drop:f},{err_short}')
+            log_detail_entry += err_msg + '\n'
+            break
+    return log_detail_entry
+
+
 def get_assoc_addr(addr, mint, url):
     cmd = ['spl-token', 'address', '--token', mint, '--owner', addr,
            '--url', url, '--verbose']
@@ -395,56 +444,16 @@ def transfer(input_path, interactive, drop_amount, mint,
         while i < len(address_list):
             addr = (address_list[i]).strip()
             if not interactive:
-
-                log_detail_entry = ""
+                log_detail_entry = ''
                 print(f"{i+1}. Airdrop to {addr}: ", end="", flush=True)
                 cmd = TransferCmd("spl-token", "transfer",
                                   mint, decimals, drop, addr, rpc_url)
                 log_detail_entry += f"{i+1}. Cmdline: {cmd.to_str()}\n"
+                log_detail_entry += try_transfer(
+                    cmd, addr, drop, 
+                    log_success, log_unconfirmed, log_failed, 
+                    TOO_MANY_REQUESTS, RPC_ERROR, UNCONFIRMED)
 
-                while True:
-                    code, out, err = run(cmd.to_list())
-                    if code == 0:
-                        print(
-                            f"{bcolors.OKGREEN}SUCCESS{bcolors.ENDC}", flush=True)
-                        sig = parse_sig(out.decode('utf-8'))
-                        with open(log_success, "a") as ls:
-                            ls.write(f"{addr},{drop:f},{sig}\n")
-                        break
-                    else:
-                        err_msg = err.decode('utf-8')
-                        if TOO_MANY_REQUESTS in err_msg:
-                            print("429, waiting 5... ", end="", flush=True)
-                            time.sleep(5)
-                            log_detail_entry += err_msg + '\n'
-                            continue
-                        if RPC_ERROR in err_msg:
-                            print("-32005 RPC Error, waiting 10... ",
-                                  end="", flush=True)
-                            log_detail_entry += err_msg + '\n'
-                            time.sleep(5)
-                            continue
-                        if UNCONFIRMED in err_msg:
-                            print(
-                                f"{bcolors.DANGER}UNCONFIRMED{bcolors.ENDC}", flush=True)
-                            with open(log_unconfirmed, "a") as lu:
-                                lu.write(f"{addr},{drop:f},{err_msg}")
-                            break
-
-                        print(f"{bcolors.FAIL}FAILED{bcolors.ENDC}", flush=True)
-                        try:
-                            err_short = (err.decode('utf-8')
-                                         ).split("\n", 1)[0] + '\n'
-                            err_short = re.sub(r"[,]", ' ', err_short)
-                        except (IndexError, Exception) as e:
-                            err_short = "Error parsing error description - read the full logs.\n"
-                        finally:
-                            with open(log_failed, "a") as lfa:
-                                lfa.write(f"{addr},{drop:f},{err_short}")
-                        break
-
-                log_detail_entry += out.decode('utf-8')
-                log_detail_entry += err.decode('utf-8')
                 with open(log_full, "a") as lf:
                     lf.write(log_detail_entry + LOG_SEPARATOR)
                 del cmd
@@ -465,55 +474,16 @@ def transfer(input_path, interactive, drop_amount, mint,
                     continue
 
                 if confirm:
-                    while True:
-                        code, out, err = run(cmd.to_list())
-                        if code == 0:
-                            print(
-                                f"  {bcolors.OKGREEN}SUCCESS{bcolors.ENDC}", flush=True)
-                            sig = parse_sig(out.decode('utf-8'))
-                            with open(log_success, "a") as ls:
-                                ls.write(f"{addr},{drop:f},{sig}\n")
-                        else:
-                            err_msg = err.decode('utf-8')
-                            if TOO_MANY_REQUESTS in err_msg:
-                                print("429 Too many requests, waiting 5... ",
-                                      end="", flush=True)
-                                log_detail_entry += err_msg + '\n'
-                                time.sleep(5)
-                                continue
-                            if RPC_ERROR in err_msg:
-                                print("-32005 RPC Error, waiting 5... ",
-                                      end="", flush=True)
-                                log_detail_entry += err_msg + '\n'
-                                time.sleep(5)
-                                continue
-                            if UNCONFIRMED in err.decode('utf-8'):
-                                print(
-                                    f"  {bcolors.WARNING}UNCONFIRMED{bcolors.ENDC}", flush=True)
-                                with open(log_unconfirmed, "a") as lu:
-                                    lu.write(f"{addr},{drop:f},{err_msg}")
-                                break
-
-                            print(
-                                f"  {bcolors.FAIL}FAILED{bcolors.ENDC}", flush=True)
-                            try:
-                                err_short = (err.decode('utf-8')
-                                             ).split("\n", 1)[0] + '\n'
-                                err_short = re.sub(r"[,]", ' ', err_short)
-                            except (IndexError, Exception):
-                                err_short = "Error reading error description - read the full logs.\n"
-                            finally:
-                                with open(log_failed, "a") as lfa:
-                                    lfa.write(f"{addr},{drop:f},{err_short}")
-
-                        log_detail_entry += out.decode('utf-8')
-                        log_detail_entry += err.decode('utf-8')
-                        with open(log_full, "a") as lf:
-                            lf.write(log_detail_entry + LOG_SEPARATOR)
-                        break
+                    log_detail_entry += try_transfer(
+                        cmd, addr, drop, 
+                        log_success, log_unconfirmed, log_failed, 
+                        TOO_MANY_REQUESTS, RPC_ERROR, UNCONFIRMED)
+                        
+                    with open(log_full, "a") as lf:
+                        lf.write(log_detail_entry + LOG_SEPARATOR)
                 elif not confirm:
                     print(
-                        f"    {bcolors.DANGER}CANCELED{bcolors.ENDC}", flush=True)
+                        f"{bcolors.DANGER}CANCELED{bcolors.ENDC}", flush=True)
                     cancel = f"{addr},{drop:f}"
                     with open(log_canceled, "a") as lc:
                         lc.write(cancel + "\n")

--- a/tools/flat-distributor/flat-distributor.py
+++ b/tools/flat-distributor/flat-distributor.py
@@ -309,6 +309,8 @@ def main():
         input_path = args.address_list
         interactive = args.interactive
         drop_amount = args.drop_amount
+        fund_recipient = args.fund_recipient
+        allow_unfunded_recipient = args.allow_unfunded_recipient
         transfer(input_path, interactive,
                     drop_amount, TOKEN_MINT, TOKEN_DECIMALS,
                     RPC_URL, LOG_FOLDER_PREFIX, FULL_LOGS,
@@ -589,6 +591,18 @@ parser_t.add_argument(
     required=True,
     help='Path to the file that contains all addresses that will receive the \
         airdrop. Each address should be in a seperate line. The file must be UTF-8 encoded.'
+)
+parser_t.add_argument(
+    '--fund-recipient',
+    action='store_true',
+    required=False,
+    help='Create the associated token account for the recipient if it does not exist.'
+)
+parser_t.add_argument(
+    '--allow-unfunded-recipient',
+    action='store_true',
+    required=False,
+    help='Complete the transfer even if the recipient\'s address is not funded.'
 )
 
 if __name__ == '__main__':

--- a/tools/flat-distributor/flat-distributor.py
+++ b/tools/flat-distributor/flat-distributor.py
@@ -255,6 +255,8 @@ class bcolors:
 def main():
     args = parser.parse_args()
     mode = args.mode
+    if not mode:
+        sys.exit('Select a subcommand (-h)')
 
     ok, env = get_env()
     if ok:
@@ -320,8 +322,6 @@ def main():
             SUCCESS_LOGS, FAILED_LOGS, CANCELED_LOGS,
             UNCONFIRMED_LOGS
         )
-    else:
-        sys.exit('No mode selected, use -h')
 
 
 def before(input_file, drop, addr_type, mint, decimals, rpc_url):  

--- a/tools/flat-distributor/flat-distributor.py
+++ b/tools/flat-distributor/flat-distributor.py
@@ -335,8 +335,6 @@ def before(input_file, drop, addr_type, mint, decimals, rpc_url):
     with open(output_file, 'w') as fw:
         for line in lines:
             try:
-                #addr = line.split(',')[0].strip()
-                #balance = float(line.split(',')[1].strip())
                 addr = line.strip()
                 ok, balance = get_balance(addr, addr_type, mint, rpc_url)
             except (IndexError, ValueError) as e:
@@ -357,37 +355,43 @@ def after(input_file, addr_type, mint, decimals, url):
     with open(input_file, 'r') as f:
         lines = f.readlines()
 
-    with open(output_file, 'w') as fw:
+    with open(output_file, 'w') as f:
+        # Read before.csv
         for line in lines:
+            output_line = ''
             try:
-                addr, _, expected = line.split(',')
-                try:
-                    expected = float(expected)
-                except ValueError:
-                    state = f'{addr},{expected},{expected},NaN'
-                    print(state)
-                    fw.write(state + '\n')
-                    continue
-            except (IndexError) as e:
-                sys.exit('Error when reading input file: ' + str(e))
+                addr, _, expected = [x.strip() for x in line.split(',')]
+                output_line += f'{addr},'
+            except IndexError as e:
+                sys.exit('Error reading input file: ' + str(e))
+
+            try:
+                expected = float(expected)
+                output_line += f'{expected:.{decimals}f},'
+            except ValueError:
+                # Not a number, expecting a No token account message
+                output_line += f'{expected},'
 
             ok, actual = get_balance(addr, addr_type, mint, url)
             if ok:
-                diff = actual - expected
                 endc = '\033[0m'
-                if diff >= 0:
-                    # green
-                    color = '\033[92m'
-                elif diff < 0:
-                    # red
-                    color = '\033[91m'
-                state = f'{addr},{expected:.{decimals}f},{actual:.{decimals}f},{diff:f}'
-                print(color + state + endc)
-                fw.write(state + '\n')
+                startc = ''
+                try:
+                    diff = actual - expected
+                    if diff >= 0:
+                        startc = '\033[92m'
+                    else:
+                        startc = '\033[91m'
+                    output_line += f'{actual:.{decimals}f},{diff:.{decimals}f}'
+                except TypeError:
+                    # Assuming actual was not a number
+                    diff = 'NaN'
+                    output_line += f'{actual},{diff}'          
             else:
-                state = f'{addr},{expected},{actual},NaN'
-                print(state)
-                fw.write(state + '\n')
+                output_line += f'{actual},NaN'
+
+            print(startc + output_line + endc)
+            f.write(output_line + '\n')
 
 
 def transfer(input_path, interactive, drop_amount, 

--- a/tools/proportional-distributor/proportional-distributor.py
+++ b/tools/proportional-distributor/proportional-distributor.py
@@ -310,6 +310,8 @@ def main():
         input_path = args.address_list
         interactive = args.interactive
         drop_amount = args.drop_amount
+        fund_recipient = args.fund_recipient
+        allow_unfunded_recipient = args.allow_unfunded_recipient
         transfer(input_path, interactive,
                  drop_amount, TOKEN_MINT, TOKEN_DECIMALS,
                  RPC_URL, LOG_FOLDER_PREFIX, FULL_LOGS,
@@ -603,6 +605,18 @@ parser_t.add_argument(
     required=True,
     help='Path to the file containing a list of addresses and balances, \
         seperated by a comma, and with each pair in a separate line.'
+)
+parser_t.add_argument(
+    '--fund-recipient',
+    action='store_true',
+    required=False,
+    help='Create the associated token account for the recipient if it does not exist.'
+)
+parser_t.add_argument(
+    '--allow-unfunded-recipient',
+    action='store_true',
+    required=False,
+    help='Complete the transfer even if the recipient\'s address is not funded.'
 )
 
 if __name__ == '__main__':

--- a/tools/proportional-distributor/proportional-distributor.py
+++ b/tools/proportional-distributor/proportional-distributor.py
@@ -256,6 +256,8 @@ class bcolors:
 def main():
     args = parser.parse_args()
     mode = args.mode
+    if not mode:
+        sys.exit('Select a subcommand (-h)')
 
     ok, env = get_env()
     if ok:
@@ -320,8 +322,6 @@ def main():
             LOG_FOLDER_PREFIX, FULL_LOGS, SUCCESS_LOGS, 
             FAILED_LOGS, CANCELED_LOGS, UNCONFIRMED_LOGS
         )
-    else:
-        sys.exit('No mode selected, use -h')
 
 
 def before(input_file, drop, addr_type, mint, decimals, rpc_url):

--- a/tools/proportional-distributor/proportional-distributor.py
+++ b/tools/proportional-distributor/proportional-distributor.py
@@ -132,6 +132,8 @@ class TransferCmd:
         self.url = url
         if options is None:
             self.options = []
+        else:
+            self.options = options
 
     def to_str(self):
         return f"{self.cmd} {self.instruction} {self.mint_address} {self.drop_amount:.{self.decimals}f} {self.recipient} {' '.join(self.options)}"
@@ -312,11 +314,12 @@ def main():
         drop_amount = args.drop_amount
         fund_recipient = args.fund_recipient
         allow_unfunded_recipient = args.allow_unfunded_recipient
-        transfer(input_path, interactive,
-                 drop_amount, TOKEN_MINT, TOKEN_DECIMALS,
-                 RPC_URL, LOG_FOLDER_PREFIX, FULL_LOGS,
-                 SUCCESS_LOGS, FAILED_LOGS, CANCELED_LOGS,
-                 UNCONFIRMED_LOGS)
+        transfer(input_path, interactive, drop_amount, 
+            fund_recipient, allow_unfunded_recipient, 
+            TOKEN_MINT, TOKEN_DECIMALS, RPC_URL, 
+            LOG_FOLDER_PREFIX, FULL_LOGS, SUCCESS_LOGS, 
+            FAILED_LOGS, CANCELED_LOGS, UNCONFIRMED_LOGS
+        )
     else:
         sys.exit('No mode selected, use -h')
 
@@ -385,9 +388,10 @@ def after(input_file, addr_type, mint, decimals, url):
                 fw.write(state + '\n')
 
 
-def transfer(input_path, interactive, drop_amount, mint,
-             decimals, rpc_url, log_prefix, full_log, success_log, failed_log,
-             canceled_log, unconfirmed_log):
+def transfer(input_path, interactive, drop_amount, 
+            fund_recipient, allow_unfunded_recipient, mint, 
+            decimals, rpc_url, log_prefix, full_log, success_log, 
+            failed_log, canceled_log, unconfirmed_log):
     SEPARATOR = "-" * 50
     LOG_SEPARATOR = "-" * 30 + "\n"
     TOO_MANY_REQUESTS = "429 Too Many Requests"
@@ -453,12 +457,17 @@ def transfer(input_path, interactive, drop_amount, mint,
             # Calculate proportional drop 
             current_balance = accounts[addr]
             drop = current_balance * proportional_factor
-            if not interactive:
+            options = []
+            if fund_recipient:
+                options.append('--fund-recipient')
+            if allow_unfunded_recipient:
+                options.append('--allow-unfunded-recipient')
+            cmd = TransferCmd("spl-token", "transfer",
+                mint, decimals, drop, addr, rpc_url, options)
 
+            if not interactive:
                 log_detail_entry = ""
                 print(f"{i+1}. Airdrop to {addr}: ", end="", flush=True)
-                cmd = TransferCmd("spl-token", "transfer",
-                                  mint, decimals, drop, addr, rpc_url)
                 log_detail_entry += f"{i+1}. Cmdline: {cmd.to_str()}\n"
                 log_detail_entry += try_transfer(
                     cmd, addr, drop,
@@ -470,12 +479,9 @@ def transfer(input_path, interactive, drop_amount, mint,
                     lf.write(log_detail_entry + LOG_SEPARATOR)
                 del cmd
                 i += 1
-
             elif interactive:
                 log_detail_entry = ""
                 print(f"{i+1}. ", end="", flush=True)
-                cmd = TransferCmd("spl-token", "transfer",
-                                  mint, decimals,  drop, addr, rpc_url)
                 log_detail_entry += f"{i+1}. Cmdline: {cmd.to_str()}\n"
 
                 confirm, switch_mode = single_transaction_prompt(


### PR DESCRIPTION
Allow users to use `--fund-recipient` and `--allow-unfunded-recipient` flags in the `transfer` sub-command of distributor tools. Both flags behave in the same manner as they do in the `spl-token transfer` command.

- `--fund-recipient` - if an address doesn't own an associated token account, the sender will create one (and fund it, this costs a bit of SOL!)
- `--allow-unfunded-recipient` - complete the transaction, even if the recipient has 0 SOL on their balance.

`check-before` and `check-after` sub-commands have been adjusted to better account for this use-case.