### PR TITLE
Feature short address type

### DIFF
--- a/tools/address-fetcher/README.md
+++ b/tools/address-fetcher/README.md
@@ -8,14 +8,14 @@ The app will create an output folder in the same directory that it is ran from, 
 ## Outputs
 The folder will contain a raw JSON file that was used to get the token account info from the Solana RPC API, a list of addresses seperated by new lines and a list of addresses and their corresponding balances for the given token, seperated by a comma. 
 
-The type of addresses that will be written to output files is selected with the option `--address-type`. Possible choices are `token` and `owner`.
+The type of addresses that will be written to output files is selected with the option `-t` or `--address-type`. Possible choices are `token` and `owner`.
 
 ## Usage
 
 The available arguments are:
 ```
   -m MINT, --mint MINT  Mint address of the SPL token
-  --address-type {owner,token}  Select the address type used in the file (owner | token).
+  -t {owner, token}, --address-type {owner,token}  Select the address type used in the output file (owner | token).
   -u URL, --url URL  URL of the Solana RPC endpoint.
   -e EXCLUDED, --excluded EXCLUDED  Path to the file that contains all addresses that will be removed from the final list. Each address should be in a seperate line, and the file must be UTF-8 encoded.
   ```

--- a/tools/address-fetcher/address-fetcher.py
+++ b/tools/address-fetcher/address-fetcher.py
@@ -224,6 +224,7 @@ parser.add_argument(
     help='Mint address of the SPL token'
 )
 parser.add_argument(
+    '-t',
     '--address-type',
     dest="atype",
     choices={'owner', 'token'},

--- a/tools/flat-distributor/README.md
+++ b/tools/flat-distributor/README.md
@@ -39,7 +39,7 @@ UNCONFIRMED_LOGS=unconfirmed.log
 ## flat-distributor check-before
 `check-before` can be used before a distribution, and will generate a CSV file containing the current balances for all recipients, and their expected balances after the distribution. The generated file will be named **before.csv** and is used as input for the `check-after` command.
 
-It is required to specify the address type used in the address list file (`--address-type {owner|token}`) and the amount of tokens that will be distributed. 
+It is required to specify the address type used in the address list file (`-t` or `--address-type {owner|token}`) and the amount of tokens that will be distributed. 
 
 ### Usage:
 `python3 flat-distributor.py check-before -a address-list.txt --address-type owner --drop 500`
@@ -70,7 +70,7 @@ Execution can be interrupted at any time with SIGINT (CTRL+C).
 
 This mode also generates a CSV file that can then be read to compare the expected vs actual balances of all recipients. 
 
-Address type must be specified with the `address-type` argument, where the type can be `owner` or `token`. 
+Address type must be specified with the `-t` or `address-type` argument, where the type can be `owner` or `token`. 
 
 ### Usage
 `python3 flat-distributor.py check-after --address-type owner --before-file before.csv`

--- a/tools/flat-distributor/flat-distributor.py
+++ b/tools/flat-distributor/flat-distributor.py
@@ -543,6 +543,7 @@ parser_b.add_argument(
     help='Path to the file containing a list of addresses, seperated into new lines.'
 )
 parser_b.add_argument(
+    '-t',
     '--address-type',
     metavar='ADDRESS_TYPE',
     dest='address_type',
@@ -563,6 +564,7 @@ parser_b.add_argument(
 parser_a = subparsers.add_parser(
     'check-after', help='Run the checker after a distribution, to check if all recipients received the expected amount of tokens.')
 parser_a.add_argument(
+    '-t',
     '--address-type',
     metavar='ADDRESS_TYPE',
     dest='address_type',

--- a/tools/proportional-distributor/proportional-distributor.py
+++ b/tools/proportional-distributor/proportional-distributor.py
@@ -556,6 +556,7 @@ parser_b.add_argument(
     help='Path to the file containing a list of addresses and balances, seperated by a comma, and with each pair in a seperate line.'
 )
 parser_b.add_argument(
+    '-t',
     '--address-type',
     metavar='ADDRESS_TYPE',
     dest='address_type',
@@ -576,6 +577,7 @@ parser_b.add_argument(
 parser_a = subparsers.add_parser(
     'check-after', help='Run the checker after a distribution, to check if all recipients received the expected amount of tokens.')
 parser_a.add_argument(
+    '-t',
     '--address-type',
     metavar='ADDRESS_TYPE',
     dest='address_type',


### PR DESCRIPTION
Can now use `-t` to specify the address-type in `address-fetcher`, `flat-distributor` and `proportional-distributor`.

Closes #11 