### PR TITLE
Hotfix handle 429 timeout

### DIFF
--- a/tools/flat-distributor/flat-distributor.py
+++ b/tools/flat-distributor/flat-distributor.py
@@ -120,32 +120,6 @@ def parse_sig(log):
         return 'Error parsing signature - check the detailed logs.'
 
 
-class TransferCmd:
-    def __init__(self, cmd, instruction, mint_address, decimals, drop_amount, recipient, url, options=None):
-        self.cmd = cmd
-        self.instruction = instruction
-        self.mint_address = mint_address
-        self.decimals = decimals
-        self.drop_amount = drop_amount
-        self.recipient = recipient
-        self.url = url
-        if options is None:
-            self.options = []
-        else:
-            self.options = options
-
-    def to_str(self):
-        return f"{self.cmd} {self.instruction} {self.mint_address} {self.drop_amount:.{self.decimals}f} {self.recipient} {' '.join(self.options)}"
-
-    def to_list(self):
-        #obj = [self.cmd, self.instruction, self.mint_address, str(self.drop_amount), self.recipient]
-        obj = [self.cmd, self.instruction, self.mint_address,
-               f"{self.drop_amount:.{self.decimals}f}", self.recipient, '--url', self.url]
-        if self.options:
-            obj.extend(self.options)
-        return obj
-
-
 def run(cmd):
     proc = subprocess.Popen(cmd,
                             stdout=subprocess.PIPE,
@@ -171,18 +145,18 @@ def try_transfer(cmd, addr, drop, log_success, log_unconfirmed, log_failed,
             break
         else:
             err_msg = err.decode('utf-8')
-            if TOO_MANY_REQUESTS in err_msg:
-                print('429, waiting 5... ', end='', flush=True)
-                time.sleep(5)
-                log_detail_entry += err_msg + '\n'
-                continue
             if RPC_ERROR in err_msg:
                 print('-32005 RPC Error, waiting 5... ',
                         end='', flush=True)
                 log_detail_entry += err_msg + '\n'
                 time.sleep(5)
                 continue
-            if UNCONFIRMED in err_msg:
+            if TOO_MANY_REQUESTS in err_msg:
+                print('429, waiting 5... ', end='', flush=True)
+                time.sleep(5)
+                log_detail_entry += err_msg + '\n'
+                continue
+            if UNCONFIRMED in err_msg or TOO_MANY_REQUESTS in err_msg:
                 print(
                     f'{bcolors.DANGER}UNCONFIRMED{bcolors.ENDC}', flush=True)
                 with open(log_unconfirmed, "a") as lu:
@@ -239,6 +213,32 @@ def get_balance(addr, addr_type, mint, url):
             return False, 'Could not find token account'
 
 
+class TransferCmd:
+    def __init__(self, cmd, instruction, mint_address, decimals, drop_amount, recipient, url, options=None):
+        self.cmd = cmd
+        self.instruction = instruction
+        self.mint_address = mint_address
+        self.decimals = decimals
+        self.drop_amount = drop_amount
+        self.recipient = recipient
+        self.url = url
+        if options is None:
+            self.options = []
+        else:
+            self.options = options
+
+    def to_str(self):
+        return f"{self.cmd} {self.instruction} {self.mint_address} {self.drop_amount:.{self.decimals}f} {self.recipient} {' '.join(self.options)}"
+
+    def to_list(self):
+        #obj = [self.cmd, self.instruction, self.mint_address, str(self.drop_amount), self.recipient]
+        obj = [self.cmd, self.instruction, self.mint_address,
+               f"{self.drop_amount:.{self.decimals}f}", self.recipient, '--url', self.url]
+        if self.options:
+            obj.extend(self.options)
+        return obj
+
+
 class bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
@@ -253,6 +253,7 @@ class bcolors:
 
 
 def main():
+    global TOKEN_MINT, TOKEN_DECIMALS, RPC_URL, LOG_FOLDER_PREFIX, FULL_LOGS, SUCCESS_LOGS, FAILED_LOGS, CANCELED_LOGS, UNCONFIRMED_LOGS
     args = parser.parse_args()
     mode = args.mode
     if not mode:
@@ -273,17 +274,6 @@ def main():
         except KeyError as e:
             sys.exit('Error reading config file: ' + str(e))
     else:
-        # Using default values for logs
-        TOKEN_MINT = ""
-        TOKEN_DECIMALS = ""
-        RPC_URL = ""
-        LOG_FOLDER_PREFIX = 'logs-'
-        FULL_LOGS = 'detailed.log'
-        SUCCESS_LOGS = 'success.log'
-        FAILED_LOGS = 'failed.log'
-        CANCELED_LOGS = 'canceled.log'
-        UNCONFIRMED_LOGS = 'unconfirmed.log'
-
         if RPC_URL == "":
             rpc_endpoints = {
                 'mainnet': 'https://api.mainnet-beta.solana.com',
@@ -303,12 +293,11 @@ def main():
         input_file = args.file_name
         address_type = args.address_type
         drop = args.drop
-        before(input_file, drop, address_type,
-               TOKEN_MINT, TOKEN_DECIMALS, RPC_URL)
+        before(input_file, drop, address_type)
     elif mode == 'check-after':
         before_file = args.before_file_name
         addr_type = args.address_type
-        after(before_file, addr_type, TOKEN_MINT, TOKEN_DECIMALS, RPC_URL)
+        after(before_file, addr_type)
     elif mode == 'transfer':
         input_path = args.address_list
         interactive = args.interactive
@@ -316,15 +305,12 @@ def main():
         fund_recipient = args.fund_recipient
         allow_unfunded_recipient = args.allow_unfunded_recipient
         transfer(input_path, interactive,drop_amount, 
-            fund_recipient, allow_unfunded_recipient, 
-            TOKEN_MINT, TOKEN_DECIMALS,RPC_URL, 
-            LOG_FOLDER_PREFIX, FULL_LOGS,
-            SUCCESS_LOGS, FAILED_LOGS, CANCELED_LOGS,
-            UNCONFIRMED_LOGS
+            fund_recipient, allow_unfunded_recipient
         )
 
 
-def before(input_file, drop, addr_type, mint, decimals, rpc_url):  
+def before(input_file, drop, addr_type):  
+    global TOKEN_MINT, TOKEN_DECIMALS, RPC_URL
     output_file = './before.csv'
     print('recipient,current-balance,expected-balance')
 
@@ -336,19 +322,20 @@ def before(input_file, drop, addr_type, mint, decimals, rpc_url):
         for line in lines:
             try:
                 addr = line.strip()
-                ok, balance = get_balance(addr, addr_type, mint, rpc_url)
+                ok, balance = get_balance(addr, addr_type, TOKEN_MINT, RPC_URL)
             except (IndexError, ValueError) as e:
                 sys.exit('Error when reading input file: ' + str(e))
             if ok:
                 expected = float(balance) + drop
                 print(f'{addr} - {balance:.3f} - {expected:.3f}')
-                fw.write(f'{addr},{balance:.{decimals}f},{expected:.{decimals}f}\n')
+                fw.write(f'{addr},{balance:.{TOKEN_DECIMALS}f},{expected:.{TOKEN_DECIMALS}f}\n')
             else:
                 print(f'{addr} - No token account - No token account')
                 fw.write(f'{addr},No token account,No token account\n')
 
 
-def after(input_file, addr_type, mint, decimals, url):
+def after(input_file, addr_type):
+    global TOKEN_MINT, TOKEN_DECIMALS, RPC_URL
     lines = []
     output_file = './after.csv'
     print('recipient,expected-balance,actual-balance,difference')
@@ -367,12 +354,12 @@ def after(input_file, addr_type, mint, decimals, url):
 
             try:
                 expected = float(expected)
-                output_line += f'{expected:.{decimals}f},'
+                output_line += f'{expected:.{TOKEN_DECIMALS}f},'
             except ValueError:
                 # Not a number, expecting a No token account message
                 output_line += f'{expected},'
 
-            ok, actual = get_balance(addr, addr_type, mint, url)
+            ok, actual = get_balance(addr, addr_type, TOKEN_MINT, RPC_URL)
             if ok:
                 endc = '\033[0m'
                 startc = ''
@@ -382,7 +369,7 @@ def after(input_file, addr_type, mint, decimals, url):
                         startc = '\033[92m'
                     else:
                         startc = '\033[91m'
-                    output_line += f'{actual:.{decimals}f},{diff:.{decimals}f}'
+                    output_line += f'{actual:.{TOKEN_DECIMALS}f},{diff:.{TOKEN_DECIMALS}f}'
                 except TypeError:
                     # Assuming actual was not a number
                     diff = 'NaN'
@@ -395,9 +382,8 @@ def after(input_file, addr_type, mint, decimals, url):
 
 
 def transfer(input_path, interactive, drop_amount, 
-            fund_recipient, allow_unfunded_recipient, mint,
-            decimals, rpc_url, log_prefix, full_log, success_log, 
-            failed_log, canceled_log, unconfirmed_log):
+            fund_recipient, allow_unfunded_recipient):
+    global TOKEN_MINT, TOKEN_DECIMALS, RPC_URL, LOG_FOLDER_PREFIX, FULL_LOGS, SUCCESS_LOGS, FAILED_LOGS, CANCELED_LOGS, UNCONFIRMED_LOGS
     SEPARATOR = "-" * 50
     LOG_SEPARATOR = "-" * 30 + "\n"
     TOO_MANY_REQUESTS = "429 Too Many Requests"
@@ -412,10 +398,10 @@ def transfer(input_path, interactive, drop_amount,
 
     print(f"{bcolors.DANGER}WARNING: MAKE SURE YOU ARE USING THE CORRECT WALLET/SUPPLY/ TO DISTRIBUTE.\nYOUR CURRENT WALLET ADDRESS IS: {current_supply.decode('utf-8')}{bcolors.ENDC}")
     print(
-        f"Running airdrop for the Token Mint: {bcolors.OKGREEN}{mint}{bcolors.ENDC}")
+        f"Running airdrop for the Token Mint: {bcolors.OKGREEN}{TOKEN_MINT}{bcolors.ENDC}")
     drop = amount_prompt(drop_amount)
     print(
-        f"Airdrop amount: {bcolors.OKGREEN}{drop:,.{decimals}f}{bcolors.ENDC}")
+        f"Airdrop amount: {bcolors.OKGREEN}{drop:,.{TOKEN_DECIMALS}f}{bcolors.ENDC}")
 
     try:
         with open(input_path) as f:
@@ -427,16 +413,16 @@ def transfer(input_path, interactive, drop_amount,
 
     # region Create log files, print locations, write headers
     timestamp = get_current_utc_time_str()
-    log_success = gen_logfile(success_log, timestamp, log_prefix)
-    log_canceled = gen_logfile(canceled_log, timestamp, log_prefix)
-    log_failed = gen_logfile(failed_log, timestamp, log_prefix)
-    log_unconfirmed = gen_logfile(unconfirmed_log, timestamp, log_prefix)
-    log_full = gen_logfile(full_log, timestamp, log_prefix)
+    log_success = gen_logfile(SUCCESS_LOGS, timestamp, LOG_FOLDER_PREFIX)
+    log_canceled = gen_logfile(CANCELED_LOGS, timestamp, LOG_FOLDER_PREFIX)
+    log_failed = gen_logfile(FAILED_LOGS, timestamp, LOG_FOLDER_PREFIX)
+    log_unconfirmed = gen_logfile(UNCONFIRMED_LOGS, timestamp, LOG_FOLDER_PREFIX)
+    log_full = gen_logfile(FULL_LOGS, timestamp, LOG_FOLDER_PREFIX)
 
     print(f"  Successful logs: (tail -f {log_success})")
     print(f"  Canceled logs: (tail -f {log_canceled})")
     print(f"  Failed logs: (tail -f {log_failed})")
-    print(f"  Unconfirmed logs: (tail -f {log_unconfirmed}")
+    print(f"  Unconfirmed logs: (tail -f {log_unconfirmed})")
     print(f"  Detailed logs: (tail -f {log_full})")
 
     with open(log_success, "a") as ls:
@@ -462,7 +448,7 @@ def transfer(input_path, interactive, drop_amount,
             if allow_unfunded_recipient:
                 options.append('--allow-unfunded-recipient')
             cmd = TransferCmd("spl-token", "transfer",
-                mint, decimals, drop, addr, rpc_url, options)
+                TOKEN_MINT, TOKEN_DECIMALS, drop, addr, RPC_URL, options)
             if not interactive:
                 log_detail_entry = ''
                 print(f"{i+1}. Airdrop to {addr}: ", end="", flush=True)
@@ -483,7 +469,7 @@ def transfer(input_path, interactive, drop_amount,
                 log_detail_entry += f"{i+1}. Cmdline: {cmd.to_str()}\n"
 
                 confirm, switch_mode = single_transaction_prompt(
-                    cmd.to_str(), drop, addr, decimals)
+                    cmd.to_str(), drop, addr, TOKEN_DECIMALS)
                 if switch_mode:
                     print("Switching to non-interactive mode.")
                     interactive = False
@@ -620,6 +606,16 @@ parser_t.add_argument(
     required=False,
     help='Complete the transfer even if the recipient\'s address is not funded.'
 )
+#endregion
 
 if __name__ == '__main__':
+    TOKEN_MINT = ""
+    TOKEN_DECIMALS = ""
+    RPC_URL = ""
+    LOG_FOLDER_PREFIX = 'logs-'
+    FULL_LOGS = 'detailed.log'
+    SUCCESS_LOGS = 'success.log'
+    FAILED_LOGS = 'failed.log'
+    CANCELED_LOGS = 'canceled.log'
+    UNCONFIRMED_LOGS = 'unconfirmed.log'
     main()

--- a/tools/flat-distributor/flat-distributor.py
+++ b/tools/flat-distributor/flat-distributor.py
@@ -151,7 +151,7 @@ def try_transfer(cmd, addr, drop, log_success, log_unconfirmed, log_failed,
                 log_detail_entry += err_msg + '\n'
                 time.sleep(5)
                 continue
-            if TOO_MANY_REQUESTS in err_msg:
+            if RETRY_ON_429 and (TOO_MANY_REQUESTS in err_msg):
                 print('429, waiting 5... ', end='', flush=True)
                 time.sleep(5)
                 log_detail_entry += err_msg + '\n'
@@ -253,7 +253,7 @@ class bcolors:
 
 
 def main():
-    global TOKEN_MINT, TOKEN_DECIMALS, RPC_URL, LOG_FOLDER_PREFIX, FULL_LOGS, SUCCESS_LOGS, FAILED_LOGS, CANCELED_LOGS, UNCONFIRMED_LOGS
+    global TOKEN_MINT, TOKEN_DECIMALS, RPC_URL, LOG_FOLDER_PREFIX, FULL_LOGS, SUCCESS_LOGS, FAILED_LOGS, CANCELED_LOGS, UNCONFIRMED_LOGS, RETRY_ON_429
     args = parser.parse_args()
     mode = args.mode
     if not mode:
@@ -304,6 +304,7 @@ def main():
         drop_amount = args.drop_amount
         fund_recipient = args.fund_recipient
         allow_unfunded_recipient = args.allow_unfunded_recipient
+        RETRY_ON_429 = args.retry_on_429
         transfer(input_path, interactive,drop_amount, 
             fund_recipient, allow_unfunded_recipient
         )
@@ -606,6 +607,14 @@ parser_t.add_argument(
     required=False,
     help='Complete the transfer even if the recipient\'s address is not funded.'
 )
+parser_t.add_argument(
+    '--retry-on-429',
+    dest='retry_on_429',
+    action='store_true',
+    default=False,
+    required=False,
+    help='Retry when a HTTP 429 error code is encountered. Use this at your own risk.'
+)
 #endregion
 
 if __name__ == '__main__':
@@ -618,4 +627,5 @@ if __name__ == '__main__':
     FAILED_LOGS = 'failed.log'
     CANCELED_LOGS = 'canceled.log'
     UNCONFIRMED_LOGS = 'unconfirmed.log'
+    RETRY_ON_429 = False
     main()

--- a/tools/proportional-distributor/proportional-distributor.py
+++ b/tools/proportional-distributor/proportional-distributor.py
@@ -256,6 +256,7 @@ class bcolors:
 def main():
     args = parser.parse_args()
     mode = args.mode
+    global TOKEN_MINT, TOKEN_DECIMALS, RPC_URL, LOG_FOLDER_PREFIX, FULL_LOGS, SUCCESS_LOGS, FAILED_LOGS, CANCELED_LOGS, UNCONFIRMED_LOGS
     if not mode:
         sys.exit('Select a subcommand (-h)')
 
@@ -274,17 +275,6 @@ def main():
         except KeyError as e:
             sys.exit('Error reading config file: ' + str(e))
     else:
-        # Using default values for logs
-        TOKEN_MINT = ""
-        TOKEN_DECIMALS = ""
-        RPC_URL = ""
-        LOG_FOLDER_PREFIX = 'logs-'
-        FULL_LOGS = 'detailed.log'
-        SUCCESS_LOGS = 'success.log'
-        FAILED_LOGS = 'failed.log'
-        CANCELED_LOGS = 'canceled.log'
-        UNCONFIRMED_LOGS = 'unconfirmed.log'
-
         if RPC_URL == "":
             rpc_endpoints = {
                 'mainnet': 'https://api.mainnet-beta.solana.com',
@@ -304,12 +294,11 @@ def main():
         input_file = args.file_name
         address_type = args.address_type
         drop = args.drop
-        before(input_file, drop, address_type,
-               TOKEN_MINT, TOKEN_DECIMALS, RPC_URL)
+        before(input_file, drop, address_type)
     elif mode == 'check-after':
         before_file = args.before_file_name
         addr_type = args.address_type
-        after(before_file, addr_type, TOKEN_MINT, TOKEN_DECIMALS, RPC_URL)
+        after(before_file, addr_type)
     elif mode == 'transfer':
         input_path = args.address_list
         interactive = args.interactive
@@ -317,14 +306,12 @@ def main():
         fund_recipient = args.fund_recipient
         allow_unfunded_recipient = args.allow_unfunded_recipient
         transfer(input_path, interactive, drop_amount, 
-            fund_recipient, allow_unfunded_recipient, 
-            TOKEN_MINT, TOKEN_DECIMALS, RPC_URL, 
-            LOG_FOLDER_PREFIX, FULL_LOGS, SUCCESS_LOGS, 
-            FAILED_LOGS, CANCELED_LOGS, UNCONFIRMED_LOGS
+            fund_recipient, allow_unfunded_recipient
         )
 
 
-def before(input_file, drop, addr_type, mint, decimals, rpc_url):
+def before(input_file, drop, addr_type):
+    global TOKEN_DECIMALS
     output_file = './before.csv'
     print('recipient,current-balance,expected-balance')
 
@@ -345,10 +332,11 @@ def before(input_file, drop, addr_type, mint, decimals, rpc_url):
             balance = accounts[addr]
             expected = balance + balance * factor
             print(f'{addr} - {balance:.3f} - {expected:.3f}')
-            fw.write(f'{addr},{balance:.{decimals}f},{expected:.{decimals}f}\n')
+            fw.write(f'{addr},{balance:.{TOKEN_DECIMALS}f},{expected:.{TOKEN_DECIMALS}f}\n')
 
 
-def after(input_file, addr_type, mint, decimals, url):
+def after(input_file, addr_type):
+    global TOKEN_MINT, TOKEN_DECIMALS, RPC_URL
     lines = []
     output_file = './after.csv'
     print('recipient,expected-balance,actual-balance,difference')
@@ -367,12 +355,12 @@ def after(input_file, addr_type, mint, decimals, url):
 
                 try:
                     expected = float(expected)
-                    output_line += f'{expected:.{decimals}f},'
+                    output_line += f'{expected:.{TOKEN_DECIMALS}f},'
                 except ValueError:
                     # Not a number, expecting a No token account message
                     output_line += f'{expected},'
 
-                ok, actual = get_balance(addr, addr_type, mint, url)
+                ok, actual = get_balance(addr, addr_type, TOKEN_MINT, RPC_URL)
                 if ok:
                     endc = '\033[0m'
                     startc = ''
@@ -382,7 +370,7 @@ def after(input_file, addr_type, mint, decimals, url):
                             startc = '\033[92m'
                         else:
                             startc = '\033[91m'
-                        output_line += f'{actual:.{decimals}f},{diff:.{decimals}f}'
+                        output_line += f'{actual:.{TOKEN_DECIMALS}f},{diff:.{TOKEN_DECIMALS}f}'
                     except TypeError:
                         # Assuming actual was not a number
                         diff = 'NaN'
@@ -395,9 +383,8 @@ def after(input_file, addr_type, mint, decimals, url):
 
 
 def transfer(input_path, interactive, drop_amount, 
-            fund_recipient, allow_unfunded_recipient, mint, 
-            decimals, rpc_url, log_prefix, full_log, success_log, 
-            failed_log, canceled_log, unconfirmed_log):
+            fund_recipient, allow_unfunded_recipient):
+    global TOKEN_MINT, TOKEN_DECIMALS, RPC_URL, LOG_FOLDER_PREFIX, FULL_LOGS, SUCCESS_LOGS, FAILED_LOGS, CANCELED_LOGS, UNCONFIRMED_LOGS
     SEPARATOR = "-" * 50
     LOG_SEPARATOR = "-" * 30 + "\n"
     TOO_MANY_REQUESTS = "429 Too Many Requests"
@@ -413,10 +400,10 @@ def transfer(input_path, interactive, drop_amount,
     print(f"{bcolors.DANGER}WARNING: MAKE SURE YOU ARE USING THE CORRECT WALLET TO DISTRIBUTE.\
         \nYour current wallet address is: {current_supply.decode('utf-8')}{bcolors.ENDC}")
     print(
-        f"Running airdrop for the Token Mint: {bcolors.OKGREEN}{mint}{bcolors.ENDC}")
+        f"Running airdrop for the Token Mint: {bcolors.OKGREEN}{TOKEN_MINT}{bcolors.ENDC}")
     total_drop = amount_prompt(drop_amount)
     print(
-        f"Total airdrop amount: {bcolors.OKGREEN}{total_drop:,.{decimals}f}{bcolors.ENDC}")
+        f"Total airdrop amount: {bcolors.OKGREEN}{total_drop:,.{TOKEN_DECIMALS}f}{bcolors.ENDC}")
 
     accounts = OrderedDict()
     try:
@@ -431,16 +418,16 @@ def transfer(input_path, interactive, drop_amount,
 
     # region Create log files, print locations, write headers
     timestamp = get_current_utc_time_str()
-    log_success = gen_logfile(success_log, timestamp, log_prefix)
-    log_canceled = gen_logfile(canceled_log, timestamp, log_prefix)
-    log_failed = gen_logfile(failed_log, timestamp, log_prefix)
-    log_unconfirmed = gen_logfile(unconfirmed_log, timestamp, log_prefix)
-    log_full = gen_logfile(full_log, timestamp, log_prefix)
+    log_success = gen_logfile(SUCCESS_LOGS, timestamp, LOG_FOLDER_PREFIX)
+    log_canceled = gen_logfile(CANCELED_LOGS, timestamp, LOG_FOLDER_PREFIX)
+    log_failed = gen_logfile(FAILED_LOGS, timestamp, LOG_FOLDER_PREFIX)
+    log_unconfirmed = gen_logfile(UNCONFIRMED_LOGS, timestamp, LOG_FOLDER_PREFIX)
+    log_full = gen_logfile(FULL_LOGS, timestamp, LOG_FOLDER_PREFIX)
 
     print(f"  Successful logs: (tail -f {log_success})")
     print(f"  Canceled logs: (tail -f {log_canceled})")
     print(f"  Failed logs: (tail -f {log_failed})")
-    print(f"  Unconfirmed logs: (tail -f {log_unconfirmed}")
+    print(f"  Unconfirmed logs: (tail -f {log_unconfirmed})")
     print(f"  Detailed logs: (tail -f {log_full})")
 
     with open(log_success, "a") as ls:
@@ -470,7 +457,7 @@ def transfer(input_path, interactive, drop_amount,
             if allow_unfunded_recipient:
                 options.append('--allow-unfunded-recipient')
             cmd = TransferCmd("spl-token", "transfer",
-                mint, decimals, drop, addr, rpc_url, options)
+                TOKEN_MINT, TOKEN_DECIMALS, drop, addr, RPC_URL, options)
 
             if not interactive:
                 log_detail_entry = ""
@@ -492,7 +479,7 @@ def transfer(input_path, interactive, drop_amount,
                 log_detail_entry += f"{i+1}. Cmdline: {cmd.to_str()}\n"
 
                 confirm, switch_mode = single_transaction_prompt(
-                    cmd.to_str(), drop, addr, decimals)
+                    cmd.to_str(), drop, addr, TOKEN_DECIMALS)
                 if switch_mode:
                     print("Switching to non-interactive mode on next address.")
                     interactive = False
@@ -635,4 +622,13 @@ parser_t.add_argument(
 )
 
 if __name__ == '__main__':
+    TOKEN_MINT = ""
+    TOKEN_DECIMALS = ""
+    RPC_URL = ""
+    LOG_FOLDER_PREFIX = 'logs-'
+    FULL_LOGS = 'detailed.log'
+    SUCCESS_LOGS = 'success.log'
+    FAILED_LOGS = 'failed.log'
+    CANCELED_LOGS = 'canceled.log'
+    UNCONFIRMED_LOGS = 'unconfirmed.log'
     main()


### PR DESCRIPTION
Implement a `--retry-on-429` option for distributors when using `transfer` sub-command.

This was previously the default behaviour, but we learned that if `spl-token transfer` returns a HTTP Too Many Requests error (429), this is not a guarantee of a failed transaction. This is a bug in how `spl-token` handles those errors and according to Solana developer support, a fix is on the way.

A transaction happening despite this error is rare, but it can happen. The safe way to treat this error is to consider the transaction as unconfirmed, until the error is fixed in `spl-token`. The `--retry-on-429` option will use the old behaviour, where the tool retried the transaction if it encountered this error.